### PR TITLE
Switches s3 url to put bucket in path.

### DIFF
--- a/lib/ex_aws/s3/direct_upload.ex
+++ b/lib/ex_aws/s3/direct_upload.ex
@@ -55,7 +55,7 @@ defmodule ExAws.S3.DirectUpload do
       iex> %ExAws.S3.DirectUpload{file_name: "image.jpg", mimetype: "image/jpeg", path: "path/to/file", bucket: "s3-bucket"}
       ...> |> ExAws.S3.DirectUpload.presigned
       ...> |> Map.get(:url)
-      "https://s3-bucket.s3.us-east-1.amazonaws.com"
+      "https://s3.us-east-1.amazonaws.com/s3-bucket"
 
       iex> %ExAws.S3.DirectUpload{file_name: "image.jpg", mimetype: "image/jpeg", path: "path/to/file", bucket: "s3-bucket"}
       ...> |> ExAws.S3.DirectUpload.presigned
@@ -90,6 +90,7 @@ defmodule ExAws.S3.DirectUpload do
 
   defp credentials(%ExAws.S3.DirectUpload{} = upload) do
     credentials = %{
+      "content-type": upload.mimetype,
       policy: policy(upload),
       "x-amz-algorithm": "AWS4-HMAC-SHA256",
       "x-amz-credential": credential(),
@@ -146,7 +147,7 @@ defmodule ExAws.S3.DirectUpload do
   end
 
   defp url(%ExAws.S3.DirectUpload{bucket: bucket}) do
-    "https://#{bucket}.s3.#{region()}.amazonaws.com"
+    "https://s3.#{region()}.amazonaws.com/#{bucket}"
   end
 
   defp credential() do

--- a/test/s3_direct_upload_test.exs
+++ b/test/s3_direct_upload_test.exs
@@ -9,8 +9,9 @@ defmodule ExAws.S3.DirectUploadTest do
     Mix.Config.read!("config/test.exs") |> Mix.Config.persist
     upload = %ExAws.S3.DirectUpload{ file_name: "file.jpg", mimetype: "image/jpeg", path: "path/in/bucket", bucket: "s3-bucket" }
     result = ExAws.S3.DirectUpload.presigned_json(upload) |> Poison.decode!
-    assert result |> get("url") == "https://s3-bucket.s3.us-east-1.amazonaws.com"
+    assert result |> get("url") == "https://s3.us-east-1.amazonaws.com/s3-bucket"
     credentials = result |> get("credentials")
+    assert credentials |> get("content-type") == "image/jpeg"
     assert credentials |> get("acl") == "public-read"
     assert credentials |> get("key") == "path/in/bucket/file.jpg"
     assert credentials |> get("policy") |> String.slice(0..9) == "eyJleHBpcm"
@@ -29,8 +30,9 @@ defmodule ExAws.S3.DirectUploadTest do
       bucket: "s3-bucket"
     }
     result = ExAws.S3.DirectUpload.presigned_json(upload) |> Poison.decode!
-    assert result |> get("url") == "https://s3-bucket.s3.us-east-1.amazonaws.com"
+    assert result |> get("url") == "https://s3.us-east-1.amazonaws.com/s3-bucket"
     credentials = result |> get("credentials")
+    assert credentials |> get("content-type") == "image/jpeg"
     assert credentials |> get("acl") == "public-read"
     assert credentials |> get("key") == "path/in/bucket/file.jpg"
     assert credentials |> get("policy") |> String.slice(0..9) == "eyJleHBpcm"


### PR DESCRIPTION
S3 has a gotcha with their bucket URLs where if you have a bucket name with dots in them, it will be counted as a nested subdomain (of an already nested subdomain). For example, if you have a bucket called `s3-bucket`, you can access it at `https://s3-bucket.s3.us-east-1.amazonaws.com`, which works because AWS tls certs are for `*.s3.{region}.amazonaws.com`. But if your bucket name is something like `co.companyname.product`, the equivalent host is `https://co.companyname.product.s3.us-east-1.amazonaws.com`, which fails ssl validation due to a mismatched host in the cert (I guess wildcards don't support multiple subdomain levels deep?).

The alternative way to access the bucket is by putting the buket in the url on the `s3.{region}.amazonaws.com` domain. So the above example would be `https://s3.us-east-1.amazonaws.com/co.companyname.product`. [Here's an article](https://shlomoswidler.com/2009/08/amazon-s3-gotcha-using-virtual-host.html) outlining the issue and the solution.

I also had to add "content-type" as a field in there because it seemed that the `["starts-with", "$Content-Type", upload.mimetype],` was failing because content-type wasn't being sent up.