### PR TITLE
Change call to :crypto for OTP 24, which removes the hmac function.

### DIFF
--- a/lib/ex_aws/s3/direct_upload.ex
+++ b/lib/ex_aws/s3/direct_upload.ex
@@ -158,7 +158,7 @@ defmodule ExAws.S3.DirectUpload do
   end
 
   defp hmac(key, data) do
-    :crypto.hmac(:sha256, key, data)
+    :crypto.mac(:hmac, :sha256, key, data)
   end
 
   defp security_token do


### PR DESCRIPTION
OTP 24 no longer has the `:crypto.hmac` function, use `:crypto.mac` instead.